### PR TITLE
password hardening: support feature in Debian 12

### DIFF
--- a/tests/hostcfgd/sample_output/PASSWORD_HARDENING_enable_digits_class/common-password
+++ b/tests/hostcfgd/sample_output/PASSWORD_HARDENING_enable_digits_class/common-password
@@ -24,7 +24,7 @@
 
 # here are the per-package modules (the "Primary" block)
 
-password    requisite      pam_cracklib.so retry=3 maxrepeat=0 minlen=8 ucredit=0 lcredit=0 dcredit=-1 ocredit=0  enforce_for_root
+password    requisite      pam_pwquality.so retry=3 maxrepeat=0 minlen=8 ucredit=0 lcredit=0 dcredit=-1 ocredit=0  enforce_for_root dictcheck=0
 
 password    required       pam_pwhistory.so remember=0 use_authtok enforce_for_root
 

--- a/tests/hostcfgd/sample_output/PASSWORD_HARDENING_enable_feature/common-password
+++ b/tests/hostcfgd/sample_output/PASSWORD_HARDENING_enable_feature/common-password
@@ -24,7 +24,7 @@
 
 # here are the per-package modules (the "Primary" block)
 
-password    requisite      pam_cracklib.so retry=3 maxrepeat=0 minlen=8 ucredit=-1 lcredit=-1 dcredit=-1 ocredit=-1 reject_username enforce_for_root
+password    requisite      pam_pwquality.so retry=3 maxrepeat=0 minlen=8 ucredit=-1 lcredit=-1 dcredit=-1 ocredit=-1 reject_username enforce_for_root dictcheck=0
 
 password    required       pam_pwhistory.so remember=10 use_authtok enforce_for_root
 


### PR DESCRIPTION
password hardening: support feature in Debian 12 by using pam_pwquality.so lib instead pam_cracklib.so, since it not supported in Debian 12